### PR TITLE
IFR Rx error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ void handleError(J1850_Operations op, J1850_ERRORS err)
     case J1850_ERR_PULSE_TOO_LONG:
         Serial.println(s + "J1850_ERR_PULSE_TOO_LONG");
         break;
+    case J1850_ERR_IFR_RX_NOT_SUPPORTED:
+        Serial.println(s + "J1850_ERR_IFR_RX_NOT_SUPPORTED");
+        break;
     default:
         // unknown error
         Serial.println(s + "ERR: " + String(err, HEX));

--- a/examples/j1850-to-serial/j1850-to-serial.ino
+++ b/examples/j1850-to-serial/j1850-to-serial.ino
@@ -95,6 +95,9 @@ void handleError(J1850_Operations op, J1850_ERRORS err)
     case J1850_ERR_PULSE_TOO_LONG:
         Serial.println(s + "J1850_ERR_PULSE_TOO_LONG");
         break;
+    case J1850_ERR_IFR_RX_NOT_SUPPORTED:
+        Serial.println(s + "J1850_ERR_IFR_RX_NOT_SUPPORTED");
+        break;
     default:
         // unknown error
         Serial.println(s + "ERR: " + String(err, HEX));

--- a/examples/sniffer/sniffer.ino
+++ b/examples/sniffer/sniffer.ino
@@ -85,6 +85,9 @@ void handleError(J1850_Operations op, J1850_ERRORS err)
     case J1850_ERR_PULSE_TOO_LONG:
         Serial.println(s + "J1850_ERR_PULSE_TOO_LONG");
         break;
+    case J1850_ERR_IFR_RX_NOT_SUPPORTED:
+        Serial.println(s + "J1850_ERR_IFR_RX_NOT_SUPPORTED");
+        break;
     default:
         // unknown error
         Serial.println(s + "ERR: " + String(err, HEX));

--- a/examples/transceiver/transceiver.ino
+++ b/examples/transceiver/transceiver.ino
@@ -86,6 +86,9 @@ void handleError(J1850_Operations op, J1850_ERRORS err)
     case J1850_ERR_PULSE_TOO_LONG:
         Serial.println(s + "J1850_ERR_PULSE_TOO_LONG");
         break;
+    case J1850_ERR_IFR_RX_NOT_SUPPORTED:
+        Serial.println(s + "J1850_ERR_IFR_RX_NOT_SUPPORTED");
+        break;
     default:
         // unknown error
         Serial.println(s + "ERR: " + String(err, HEX));

--- a/src/j1850vpw.h
+++ b/src/j1850vpw.h
@@ -22,7 +22,8 @@ enum J1850_ERRORS {
     J1850_ERR_PULSE_TOO_SHORT       = 0x85,
     J1850_ERR_PULSE_OUTSIDE_FRAME   = 0x86,
     J1850_ERR_ARBITRATION_LOST      = 0x87,
-    J1850_ERR_PULSE_TOO_LONG        = 0x88
+    J1850_ERR_PULSE_TOO_LONG        = 0x88,
+    J1850_ERR_IFR_RX_NOT_SUPPORTED  = 0x89
 };
 
 enum J1850_Operations {
@@ -59,6 +60,7 @@ private:
     volatile uint8_t _currState;
     volatile uint8_t _bit;
     volatile uint8_t _byte;
+    volatile bool _IFRDetected;
     uint8_t _buff[BS];
     uint8_t *msg_buf;
 


### PR DESCRIPTION
Updated the RX function to handle IFR responses more gracefully. Currently responses fall through and fail CRC and are silently lost. Updated functionality flags an error that IFR is present but the non IFR part of the message is still returned which is far more useful.