### PR TITLE
RAMReduction

### DIFF
--- a/src/storage.h
+++ b/src/storage.h
@@ -11,7 +11,7 @@
 #include "common.h"
 
 #ifndef STORAGE_SIZE
-#define STORAGE_SIZE 60
+#define STORAGE_SIZE 40
 #endif
 
 class StorageItem

--- a/src/storage.h
+++ b/src/storage.h
@@ -11,7 +11,7 @@
 #include "common.h"
 
 #ifndef STORAGE_SIZE
-#define STORAGE_SIZE 40
+#define STORAGE_SIZE 20
 #endif
 
 class StorageItem


### PR DESCRIPTION
Storage buffer is too big for ATmega328 boards. Examples have 83% RAM used and will have execution issues. Reduced the buffer from 60 to 40 which takes RAM usage down to 70%.
As a lot of people use these boards I think the RAM usage should be reduced to fit them.